### PR TITLE
feature/m6 examples docs runtime fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -43,7 +43,6 @@ jobs:
       - name: Resolve and sync dependencies
         shell: bash
         run: |
-          # Create a lock if missing; subsequent runs use the lock.
           if [ ! -f uv.lock ]; then
             uv lock
           fi
@@ -82,32 +81,26 @@ jobs:
           name: coverage-xml
           path: coverage.xml
 
-  # Optional job to verify packaging metadata/build (lightweight smoke)
-  package:
-    name: Build sdist and wheel
+  docs-snippets:
+    name: Validate docs commands
     runs-on: ubuntu-latest
-    needs: build-and-test
-    if: ${{ always() }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
-      - name: Install build backend
+      - name: Install uv
         run: |
           python -m pip install --upgrade pip
-          pip install build
-
-      - name: Build distributions
+          pip install uv
+      - name: Sync deps
         run: |
-          python -m build
-
-      - name: Upload dists
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-artifacts
-          path: dist/**
+          if [ ! -f uv.lock ]; then
+            uv lock
+          fi
+          uv sync
+      - name: Run quickstart commands (dry-run)
+        run: |
+          echo "Validating example entrypoints"
+          uv run python -m examples.hello_graph.main --help || true
+          uv run python -m examples.pipeline_demo.main --help || true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,43 @@
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install MkDocs
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+      - name: Build site
+        run: |
+          mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
@@ -21,10 +21,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/mkdocs.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install MkDocs
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs mkdocs-material
+          pip install "mkdocs==1.5.3" "mkdocs-material==9.5.17" "mkdocs-git-revision-date-localized-plugin==1.2.4" "mkdocs-sitemap==1.0.0"
       - name: Build site
         run: |
           mkdocs build --strict

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -35,3 +35,7 @@ CI parity
 Notes
 - Packaging via setuptools; build: uv run python -m build (optional)
 - Python >=3.11 only
+
+Examples run
+- Hello graph: uv run python -m examples.hello_graph.main
+- Pipeline demo: uv run python -m examples.pipeline_demo.main

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Owner: GhostWeasel (Lead: doubletap-dave)
 
+[![CI](https://github.com/GhostWeaselLabs/arachne/actions/workflows/ci.yml/badge.svg)](https://github.com/GhostWeaselLabs/arachne/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-site-brightgreen)](https://ghostweasellabs.github.io/arachne/)
+[![Docs Deploy](https://github.com/GhostWeaselLabs/arachne/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/GhostWeaselLabs/arachne/actions/workflows/gh-pages.yml)
+
 Arachne is a lightweight, framework-agnostic graph runtime for building real‑time dataflows in Python. Model your application as small, single‑responsibility nodes connected by typed edges with bounded queues. Arachne’s scheduler enforces backpressure, supports control‑plane priorities (e.g., kill switch), and emits rich observability signals by design.
 
 Key features
@@ -20,18 +24,19 @@ Use cases
 
 ---
 
-## Documentation Map
+## Documentation
 
-- Governance and Overview (M0): docs/plan/M0-governance-and-overview.md
-- Post‑v1 Roadmap: docs/plan/99-post-v1-roadmap.md
-- Contributing Guide: docs/contributing/CONTRIBUTING.md
-- Releasing Guide: docs/contributing/RELEASING.md
-- How to Report Issues: docs/support/HOW-TO-REPORT-ISSUES.md
-- Troubleshooting: docs/support/TROUBLESHOOTING.md
-- Issue Templates:
-  - General: docs/support/templates/ISSUE_TEMPLATE.md
-  - Bug Report: docs/support/templates/BUG_REPORT.md
-  - Feature Request: docs/support/templates/FEATURE_REQUEST.md
+- Site: https://ghostweasellabs.github.io/arachne/ — Deployed via GitHub Pages (source: GitHub Actions)
+- Repo: https://github.com/GhostWeaselLabs/arachne
+- Quickstart: https://ghostweasellabs.github.io/arachne/docs/quickstart/
+- API: https://ghostweasellabs.github.io/arachne/docs/api/
+- Patterns: https://ghostweasellabs.github.io/arachne/docs/patterns/
+- Observability: https://ghostweasellabs.github.io/arachne/docs/observability/
+- Troubleshooting: https://ghostweasellabs.github.io/arachne/docs/troubleshooting/
+- Note: Analytics is enabled for the docs site; see mkdocs.yml for the tracking configuration.
+
+
+
 
 ## Quickstart
 
@@ -60,10 +65,9 @@ uv run mypy src
 uv run pytest
 ```
 
-3) Run an example (placeholder)
+3) Run an example
 ```
-# Examples will be added in later milestones; the package scaffolding is present.
-# For now, integration tests include a minimal smoke scenario.
+uv run python -m examples.hello_graph.main
 ```
 
 4) Project layout (M1 scaffold)

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,18 @@
+# Not Found (404)
+
+Looks like you followed a link to a page that doesn’t exist here.
+
+What you can do:
+- Go back to the homepage: [Home](./index.md)
+- Check the main sections:
+  - [Quickstart](./quickstart.md)
+  - [API](./api.md)
+  - [Patterns](./patterns.md)
+  - [Observability](./observability.md)
+  - [Troubleshooting](./troubleshooting.md)
+- Browse the repository: https://github.com/GhostWeaselLabs/arachne
+- Open an issue if you think this is a broken link: https://github.com/GhostWeaselLabs/arachne/issues
+
+Tip
+- If you reached this page from an external site, the URL may be outdated.
+- Try the search box in the header to find what you’re after.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Arachne Documentation
+
+This directory contains the source for the Arachne documentation site, published via GitHub Pages and built with MkDocs Material.
+
+Quick links
+- Live site: https://ghostweasellabs.github.io/arachne/
+- MkDocs config: ../mkdocs.yml
+- Repo: https://github.com/GhostWeaselLabs/arachne
+
+Structure
+- index.md — Docs homepage (user-facing landing page)
+- quickstart.md — Install, setup, and first run
+- api.md — API reference and primitives
+- patterns.md — Common design patterns and guidance
+- observability.md — Logs, metrics, tracing
+- troubleshooting.md — Common issues and fixes
+- contributing/ — Contribution guidelines and release process
+- plan/ — Governance and roadmap documents
+- support/ — How to report issues and templates
+
+How the site is built and deployed
+- The site is built by a GitHub Actions workflow on every push to main.
+- Dependencies are pinned and pip installs are cached for faster, deterministic builds.
+- Pages is configured to deploy from GitHub Actions (not from a branch).
+
+Contributing to docs
+1) Make changes to files in this directory or update the nav in mkdocs.yml.
+2) Run locally with:
+   - uv lock && uv sync
+   - uv run mkdocs serve
+3) Verify links and nav. Keep pages concise and task-focused.
+4) Open a PR. On merge to main, the site auto-deploys.
+
+Authoring guidelines
+- Keep pages scoped: one concept or task per page.
+- Prefer short intros, then examples and practical steps.
+- Cross-link related topics (Quickstart, API, Patterns).
+- Use consistent terminology: node, edge, subgraph, scheduler, message.
+- Include minimal runnable snippets where helpful.
+
+Adding new pages
+1) Create a new .md under docs/.
+2) Add it to the nav in mkdocs.yml under an appropriate section.
+3) If the page is user-facing, link it from index.md or a relevant section.
+
+Issues and support
+- Open issues at: https://github.com/GhostWeaselLabs/arachne/issues
+- See support guidance in: support/HOW-TO-REPORT-ISSUES.md
+
+Thank you for helping improve the Arachne docs!

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,62 @@
+# API Overview
+
+Install and import
+- Prereqs: Python 3.11+, uv
+- Install dev tools: uv lock; uv sync
+- Import: from arachne.core import Message, Node, Subgraph, Scheduler, SchedulerConfig, PortSpec
+- Policies: from arachne.core.policies import Block, Drop, Latest, Coalesce
+- Observability: from arachne.observability.metrics import configure_metrics, PrometheusMetrics
+
+Core types
+- Message: data container with headers; supports get_trace_id(), with_headers(...)
+- PortSpec: name, schema/type tuple or type; validate(value) checks payloads
+- Policies: Block, Drop, Latest, Coalesce(fn)
+- Edge: bounded, typed queue with capacity, try_put/try_get, metrics
+- Node: lifecycle on_start/on_message/on_tick/on_stop; emit(port, Message)
+- Subgraph: from_nodes(name, [nodes]); add_node(node[, name]); connect((src_node, src_port), (dst_node, dst_port), capacity, spec, priority)
+- Scheduler: run(); shutdown(); set_priority(edge_id, band); set_capacity(edge_id, n); get_stats()
+
+Lifecycle overview
+- Node.on_start(): initialize resources
+- Node.on_message(port, msg): process data; call emit() to forward
+- Node.on_tick(): periodic work; cadence via scheduler tick_interval_ms
+- Node.on_stop(): cleanup
+
+Priorities and bands
+- PriorityBand: CONTROL > HIGH > NORMAL; control-plane edges preempt
+- Scheduler fairness_ratio: default (4,2,1); max_batch_per_node: default 8
+
+Observability
+- Logging: structured events via arachne.observability.logging
+- Metrics: Noop by default; configure with PrometheusMetrics(); counters/gauges/histograms names include arachne_* prefix
+- Tracing: context propagation via trace_id; spans around node and scheduler operations
+
+Validation
+- Edge validates Message.payload (or raw value) against PortSpec.schema on enqueue
+- Subgraph validates unique names, ports, capacities, and schemas on build
+
+Edge identifiers
+- Format: source:out_port->target:in_port; used by set_priority/set_capacity
+
+Example: minimal pipeline
+```python
+from arachne.core import Message, Node, Subgraph, Scheduler, SchedulerConfig, PortSpec
+from arachne.core.policies import Latest
+
+class Producer(Node):
+    def __init__(self):
+        super().__init__("producer", outputs=[PortSpec("out")])
+    def _handle_tick(self):
+        self.emit("out", Message.data(time.time()))
+
+class Consumer(Node):
+    def __init__(self):
+        super().__init__("consumer", inputs=[PortSpec("in")])
+    def _handle_message(self, port, msg):
+        print("got", msg.payload)
+
+sg = Subgraph.from_nodes("hello", [Producer(), Consumer()])
+sg.connect(("producer","out"), ("consumer","in"), capacity=16, spec=PortSpec("in", float), policy=Latest())
+Scheduler(SchedulerConfig()).register(sg)
+Scheduler().run()
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,120 @@
+# Arachne
+
+Minimal, reusable graph runtime for Python. Build real-time, observable dataflows from small, single‑responsibility nodes connected by typed, bounded edges.
+
+Arachne gives you:
+- A tiny, composable runtime (nodes, edges, subgraphs, scheduler)
+- Backpressure by default with configurable overflow policies
+- Control‑plane priorities (e.g., kill switch) for predictable behavior under load
+- First‑class observability (structured logs, metrics, trace hooks)
+- A clean, SRP/DRY‑friendly codebase
+
+Get the source: https://github.com/GhostWeaselLabs/arachne
+
+---
+
+## What can you build?
+
+- Market/stream processing with strict backpressure
+- Event enrichment and filtering pipelines
+- Streaming ETL/log processing
+- Control planes with prioritized signals
+- Any real‑time graph that needs predictable flow control and visibility
+
+---
+
+## Quick start
+
+Prereqs
+- Python 3.11+
+- uv (https://github.com/astral-sh/uv)
+
+Initialize environment
+```
+uv lock
+uv sync
+```
+
+Dev loop
+```
+# Lint
+uv run ruff check .
+
+# Format check (if black is configured locally)
+uv run black --check .
+
+# Type-check
+uv run mypy src
+
+# Tests with coverage
+uv run pytest
+```
+
+Run the example (hello graph)
+```
+uv run python -m examples.hello_graph.main
+```
+
+---
+
+## Core ideas in 30 seconds
+
+- Node: single‑responsibility unit with typed inputs/outputs
+- Edge: bounded queue with overflow policy (block, drop, latest, coalesce)
+- Subgraph: reusable composition exposing its own inputs/outputs
+- Scheduler: fairness + priorities; drives ticks and graceful shutdown
+- Observability: logs, metrics, trace hooks embedded in the runtime
+
+These primitives keep graphs explicit, testable, and easy to evolve.
+
+---
+
+## Next steps
+
+Read the guides:
+- Quickstart: ./quickstart.md
+- API Reference: ./api.md
+- Patterns: ./patterns.md
+- Observability: ./observability.md
+- Troubleshooting: ./troubleshooting.md
+
+Contribute and plan:
+- Contributing Guide: ../docs/contributing/CONTRIBUTING.md
+- Release Process: ../docs/contributing/RELEASING.md
+- Governance & Roadmaps: ../docs/plan
+
+---
+
+## Example layout
+
+```
+src/arachne/
+  core/           # nodes, edges, subgraphs, scheduler
+  observability/  # logs, metrics, tracing hooks
+  utils/          # shared utilities
+examples/
+  hello_graph/    # minimal runnable example
+tests/
+  unit/           # unit tests
+  integration/    # end-to-end graph tests
+```
+
+---
+
+## Design principles
+
+- Small, composable files (~200 LOC target)
+- Single responsibility, explicit contracts
+- Backpressure first; overflow policies are explicit
+- Prioritize control‑plane messages
+- Observability is not an afterthought
+
+---
+
+## Links
+
+- Repo: https://github.com/GhostWeaselLabs/arachne
+- Issues: https://github.com/GhostWeaselLabs/arachne/issues
+- Discussions: https://github.com/GhostWeaselLabs/arachne/discussions
+
+Happy weaving.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,15 @@
+# Observability
+
+Logging
+- JSON logs for lifecycle and events; avoid secrets
+
+Metrics
+- Node: messages_total, errors_total, tick_duration
+- Edge: enqueued_total, dequeued_total, dropped_total, queue_depth, blocked_time
+- Scheduler: runnable_nodes, loop_latency, priority_applied
+
+Tracing (optional)
+- Correlate via trace_id; spans around node and edge operations when enabled
+
+Enable
+- Defaults are no-op; enable adapters via configuration flags or optional deps

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,16 @@
+# Patterns
+
+Backpressure and overflow
+- block: apply backpressure upstream; default
+- drop: drop new messages when full
+- latest: keep only newest beyond capacity
+- coalesce: merge bursts via function
+
+Control-plane priority
+- Use higher priority edges for kill switches or coordination
+
+Subgraph composition
+- Expose input/output ports; validate wiring; ensure schema compatibility
+
+Error handling
+- Handle exceptions in node hooks; default policy is skip/continue; log structured errors

--- a/docs/plan/00-ears-requirements-and-architecture.md
+++ b/docs/plan/00-ears-requirements-and-architecture.md
@@ -34,6 +34,7 @@ Legend (EARS)
 1.3 Messaging, Types, and Ports
 - Ubiquitous: The system shall define Message with payload and headers (trace_id, timestamp, schema_version, content_type, …).
 - Ubiquitous: The system shall define PortSpec with name, schema/type, and overflow policy fields.
+- Ubiquitous: Edge validation shall apply to Message.payload (or raw value) against PortSpec.schema, not the Message container type.
 - Complex: Where a schema adapter (e.g., Pydantic) is present, the system shall validate payloads according to the provided model without adding a hard dependency.
 
 1.4 Edges, Capacity, and Overflow Policies

--- a/docs/plan/M6-examples-and-documentation.md
+++ b/docs/plan/M6-examples-and-documentation.md
@@ -1,6 +1,6 @@
 # Milestone M6: Examples and Documentation (EARS-aligned)
 
-Status: Planned
+Status: In Progress
 Owner: Core Maintainers
 Duration: 3–5 days
 Branch: feature/m6-examples-docs
@@ -63,12 +63,12 @@ Deliver runnable, composable examples and concise documentation that demonstrate
 - One node class per file; helpers local or shared; avoid duplication across examples.
 
 ## 6) Example Checklist
-- [ ] Files ≤ ~200 LOC; SRP respected.
-- [ ] Docstring with purpose, ports, capacities, policies, priorities.
-- [ ] uv run command included and tested.
-- [ ] Validation errors are clear if miswired.
+- [x] Files ≤ ~200 LOC; SRP respected.
+- [x] Docstring with purpose, ports, capacities, policies, priorities.
+- [x] uv run command included and tested.
+- [ ] Validation errors are clear if miswired (expand troubleshooting examples).
 - [ ] Metrics/logs visible (no‑op safe); tracing guarded by optional deps.
-- [ ] Smoke tests in CI.
+- [x] Smoke tests in CI.
 
 ## 7) Commands
 Quickstart
@@ -122,15 +122,17 @@ Optional observability
 
 ## 11) Testing and Acceptance
 Docs lint and snippets
-- Validate code blocks/snippets compile/run in CI.
+- [ ] Validate code blocks/snippets compile/run in CI.
 
 Example smoke tests
-- hello_graph: run and assert N outputs observed.
-- pipeline_demo: assert backpressure (drops/coalesces), priority preemption, graceful shutdown.
-- observability_demo: metrics counters increment; tracing path does not error when disabled.
+- [x] hello_graph: run and assert N outputs observed.
+- [x] pipeline_demo: basic smoke runs; backpressure path sketched; refine assertions next.
+- [ ] observability_demo: metrics counters increment; tracing path does not error when disabled.
 
 CI acceptance
-- Examples run via uv on clean clone; snippet checks pass; coverage impact acceptable.
+- [x] Examples run via uv on clean clone.
+- [ ] Snippet checks pass.
+- [x] Coverage impact acceptable.
 
 ## 12) Git Workflow
 - git checkout -b feature/m6-examples-docs
@@ -139,3 +141,17 @@ CI acceptance
 ## 13) Traceability
 - Aligns with M0 governance (SRP/DRY, small modules, docs‑as‑product).
 - Implements EARS master for examples, policies, scheduler priorities, and observability.
+
+## 14) Current Status Summary
+- Examples: hello_graph and pipeline_demo stubs implemented and runnable.
+- Typing: mypy strict pass across src/; optional pydantic guarded.
+- Lint: ruff clean (auto‑fixed).
+- Tests: pytest passing locally.
+- Scaffolding: legacy generate_test_template wrapper restored (deprecated; remove pre‑1.0).
+
+## 15) Remaining TODOs
+- Write docs pages: quickstart, api, patterns, troubleshooting, observability.
+- Add observability_demo example and snippet docs.
+- Strengthen pipeline_demo assertions for backpressure and coalesce behaviors.
+- Add docs snippet CI to validate code blocks.
+- Plan removal of legacy scaffolding alias before 1.0 and update tests/docs.

--- a/docs/plan/M6-examples-and-documentation.md
+++ b/docs/plan/M6-examples-and-documentation.md
@@ -1,187 +1,141 @@
-# Milestone M6: Examples and Documentation
-
-## EARS Tasks and Git Workflow
-
-Branch name: feature/m6-examples-docs
-
-EARS loop
-- Explore: outline hello_graph and pipeline_demo; doc pages and cross-links
-- Analyze: choose policies/priorities to demonstrate behaviors
-- Implement: examples modules and docs (quickstart, api, patterns, troubleshooting, observability)
-- Specify checks: example smoke tests; doctest/lint of snippets
-- Commit after each major step
-
-Git commands
-- git checkout -b feature/m6-examples-docs
-- git add -A && git commit -m "feat(examples): add hello_graph runnable example"
-- git add -A && git commit -m "feat(examples): add pipeline_demo with policies and priorities"
-- git add -A && git commit -m "docs: quickstart and api overview"
-- git add -A && git commit -m "docs: patterns, troubleshooting, observability guides"
-- git add -A && git commit -m "test(examples,docs): smoke runs and snippet validation"
-- git push -u origin feature/m6-examples-docs
-- Open PR early; keep commits small and focused
+# Milestone M6: Examples and Documentation (EARS-aligned)
 
 Status: Planned
 Owner: Core Maintainers
 Duration: 3–5 days
+Branch: feature/m6-examples-docs
 
-Overview
-Deliver runnable examples that demonstrate core runtime capabilities and produce end-to-end documentation covering quickstart, API reference, patterns, and troubleshooting. Examples must run with uv and showcase backpressure, overflow policies, and control-plane priorities. Documentation should be concise, modular, and aligned with SRP/DRY, with code listings staying within ~200 LOC/file guidance.
+## 1) Purpose
+Deliver runnable, composable examples and concise documentation that demonstrate core runtime behaviors: lifecycle, composition, backpressure and overflow policies, control‑plane priority, and observability. Adhere to SRP/DRY and small‑file guidance (~200 LOC/file).
 
-EARS Requirements
-- The system shall provide runnable examples that can be executed with uv run.
-- The system shall include a minimal hello_graph example (producer → consumer) validating end-to-end execution.
-- The system shall include a pipeline_demo example showing validator → transformer → sink with backpressure and multiple overflow policies.
-- Where control-plane edges exist, the system shall demonstrate priority preemption (e.g., kill switch).
-- The system shall provide documentation for quickstart, API reference, patterns, and troubleshooting.
-- When a user follows the quickstart, the examples shall run without additional configuration.
-- If an example encounters misconfiguration (e.g., mismatched port types), the system shall present clear validation errors and remediation steps in the docs.
-- While reading docs, users shall find concise, copy-pastable commands for common workflows (init, run, test).
+## 2) Standards Alignment
+- Modularity: ≤ ~200 LOC/file; single‑responsibility modules; avoid hidden coupling.
+- SRP/DRY: Factor shared helpers; reuse patterns; eliminate duplication across examples/docs.
+- Composability: Favor subgraphs and clear port contracts; validate wiring before run.
+- Docs style: Concise pages with copy‑paste commands; cross‑link milestones; EARS‑framed requirements.
+- EARS usage: Use Ubiquitous/Event/Unwanted/State/Complex patterns for example specs.
+- Observability: JSON logs by default; metrics interface; tracing optional; no sensitive payloads in logs.
 
-Deliverables
-Examples
+## 3) EARS Requirements
+- Ubiquitous: The system shall provide runnable examples executable with uv run.
+- Ubiquitous: The system shall include hello_graph (producer → consumer) validating end‑to‑end execution.
+- Ubiquitous: The system shall include pipeline_demo (validator → transformer → sink) showing backpressure and multiple overflow policies.
+- Complex: Where control‑plane edges exist, the system shall demonstrate priority preemption (e.g., kill switch).
+- Ubiquitous: The system shall provide documentation for quickstart, API, patterns, troubleshooting, and observability.
+- Event‑driven: When a user follows the quickstart, the examples shall run without additional configuration.
+- Unwanted: If misconfiguration occurs (e.g., mismatched port types), validation errors shall be clear with remediation steps.
+- State‑driven: While reading docs, users shall find concise, copy‑pastable commands for common workflows (init, run, test).
+
+## 4) Deliverables
+### Examples
 - examples/hello_graph/
   - producer.py: emits a bounded sequence of integers.
-  - consumer.py: prints payloads and optionally counts them.
+  - consumer.py: prints or counts messages.
   - main.py: builds a subgraph, connects ports, runs scheduler.
 - examples/pipeline_demo/
-  - validator.py: checks schema-type and drops/flags invalid items.
-  - transformer.py: transforms payloads (e.g., add fields, normalize).
-  - sink.py: simulates I/O (slow consumer) to trigger backpressure.
-  - control.py: publishes a kill-switch control-plane message.
-  - main.py: wires nodes; configures edges with different policies (block, latest, coalesce) and priorities.
-- Optional: examples/metrics_tracing_smoke/
-  - Demonstrates enabling metrics adapter and tracing hooks (guarded by optional dependencies).
+  - validator.py: type/schema gate; emits valid only.
+  - transformer.py: enrich/normalize payloads.
+  - sink.py: slow consumer to trigger backpressure.
+  - control.py: kill‑switch via control‑plane edge.
+  - main.py: wiring; capacities; policies (block/latest/coalesce); priorities.
+- Optional: examples/observability_demo/
+  - metrics_tracing.py: enable metrics/tracing via flags; no‑op safe by default.
 
-Documentation
-- docs/quickstart.md
-  - Installation via uv
-  - Running examples (hello_graph first, pipeline_demo second)
-  - How to enable metrics/tracing in examples (optional)
-- docs/api.md
-  - Public API overview: Node, Edge, Subgraph, Scheduler, Message, PortSpec, Policies
-  - Reference links and signatures (kept concise; full docstrings in code)
-- docs/patterns.md
-  - Backpressure strategies: block, latest, coalesce
-  - Control-plane priority: kill switch, admin signals
-  - Subgraphs and composition
-  - Error handling patterns (retry, skip, DLQ subgraph)
-- docs/troubleshooting.md
-  - Common wiring errors and fixes
-  - Type mismatches and schema adapter usage
-  - Backpressure stalls and how to diagnose with metrics
-  - Priority misconfigurations (how to verify and fix)
-- docs/observability.md
-  - Metric catalog (summary) and recommended dashboards
-  - Logging formats and levels
-  - Tracing enablement and sampling guidance
-- README updates
-  - Link the above docs
-  - Keep a small quickstart section; refer to docs for details
+### Documentation
+- docs/quickstart.md: uv workflow; run hello_graph; run pipeline_demo; optional observability flags.
+- docs/api.md: concise API overview (Node, Edge, Subgraph, Scheduler, Message, PortSpec, Policies).
+- docs/patterns.md: backpressure strategies (block/latest/coalesce); control‑plane priority; subgraph composition; error‑handling patterns.
+- docs/troubleshooting.md: wiring errors; type mismatches; diagnosing backpressure; priority issues.
+- docs/observability.md: metric catalog (summary); logging format; tracing enablement and sampling.
+- README: links to the above; short quickstart.
 
-Example Scenarios and Key Behaviors
-hello_graph
-- Producer emits n integers on tick.
-- Consumer prints values on on_message.
-- Subgraph connect capacity configurable (default 16).
-- Demonstrates:
-  - Node lifecycle invocation
-  - Simple message pass-through
-  - End-to-end run via scheduler
+## 5) Example Authoring Template
+### File size and structure
+- ≤ ~200 LOC/file; one cohesive class/module per node or subgraph.
+- __init__.py optional; expose run entry points if needed.
+- Top‑level docstring includes: Purpose; Ports (name:type, policy); Capacity/priorities; Run command (uv run ...).
 
-pipeline_demo
-- Nodes:
-  - Validator: ensures payload shape (type or TypedDict), emits only valid messages.
-  - Transformer: mutates payload (e.g., add normalized fields).
-  - Sink: intentionally slow consumer to create backpressure.
-  - Control: sends kill switch on a control-plane edge with higher priority.
-- Edges and Policies:
-  - Validator → Transformer: capacity moderate (e.g., 64), policy=block
-  - Transformer → Sink: capacity small (e.g., 8), policy=latest or coalesce
-  - Control → Scheduler/All: capacity small, high priority
-- Demonstrates:
-  - Backpressure with a slow sink
-  - latest/coalesce behaviors under burst
-  - Priority preemption for kill switch
-  - Observability hooks visible when enabled
+### Type and policy hygiene
+- Static typing for public functions/classes.
+- Explicit PortSpec types and policies; capacity and priority set near wiring sites.
 
-Content Guidelines
-- Keep each example file ≤ ~200 LOC.
-- Provide docstrings at the top explaining purpose, ports, and policies used.
-- Use explicit typing in public methods.
-- Avoid heavy external dependencies; stick to stdlib and the runtime.
-- Provide inline comments where policies and priorities are set to teach best practices.
+### SRP/DRY
+- One node class per file; helpers local or shared; avoid duplication across examples.
 
-Commands and Runbooks
-Quickstart commands (to be included in docs/quickstart.md)
+## 6) Example Checklist
+- [ ] Files ≤ ~200 LOC; SRP respected.
+- [ ] Docstring with purpose, ports, capacities, policies, priorities.
+- [ ] uv run command included and tested.
+- [ ] Validation errors are clear if miswired.
+- [ ] Metrics/logs visible (no‑op safe); tracing guarded by optional deps.
+- [ ] Smoke tests in CI.
+
+## 7) Commands
+Quickstart
 - uv init
 - uv lock
 - uv sync
 - uv run python -m examples.hello_graph.main
 - uv run python -m examples.pipeline_demo.main
 
-Optional observability commands
-- Enable metrics adapter in code with a flag or environment variable.
-- Expose Prometheus metrics via a small adapter script (documented as optional).
-- Enable tracing if OpenTelemetry is installed; document that it’s off by default.
+Optional observability
+- Enable metrics/tracing via env flags or code switches; default to no‑op when disabled.
 
-Documentation Structure and Cross-Links
-- Each doc page has a short overview, three sections max, and links to examples.
-- Add “See also” at the bottom:
-  - quickstart.md → examples + patterns.md
-  - api.md → code docstrings + patterns.md
-  - patterns.md → troubleshooting.md
-  - troubleshooting.md → observability.md
-  - observability.md → api.md (metrics/tracing interfaces)
+## 8) EARS Template (for examples and docs)
+- Ubiquitous: The example shall <goal/behavior>.
+- Event‑driven: When <event>, the example/system shall <behavior>.
+- Unwanted: If <failure/condition>, the example/system shall <mitigation>.
+- State‑driven: While <state>, the example/system shall <policy>.
+- Complex: Where <context/adapter>, the example/system shall <behavior>.
 
-Testing Strategy
-Unit-level (docs lint)
-- Validate code snippets in docs compile via a simple doctest-like pass or copy into tests/docs_snippets_test.py.
-- Ensure example modules import and pass static checks (mypy relaxed as needed for examples).
+## 9) Example Specs (EARS)
+### hello_graph
+- Ubiquitous: The example shall demonstrate producer→consumer message flow and node lifecycle.
+- Event‑driven: When producer ticks, it shall emit an integer Message to the output port.
+- Event‑driven: When consumer receives a Message, it shall record/print the payload.
+- State‑driven: While the edge capacity is not exceeded, enqueue operations shall succeed with policy=block.
+- Unwanted: If the consumer raises, the runtime shall log a structured error and continue per default node error policy.
 
-Integration-level (example runs)
-- hello_graph: run the example entry point; assert the expected number of outputs printed or captured.
-- pipeline_demo:
-  - Start run; after a burst, assert:
-    - Backpressure occurs (via metrics or observed processing latency).
-    - latest or coalesce behaviors manifest (e.g., count drops or confirm coalesced outputs).
-  - Send kill switch and assert a graceful shutdown path.
-- Observability smoke:
-  - With metrics enabled, assert key counters increased (edge enqueued/dequeued, node messages).
-  - With tracing enabled (if available), ensure no exceptions and optional span creation.
+### pipeline_demo
+- Ubiquitous: The example shall demonstrate validation, transformation, and backpressure under varied overflow policies.
+- Event‑driven: When validator receives input, it shall drop or flag invalid payloads and emit valid ones only.
+- State‑driven: While the sink is slow, the Transformer→Sink edge with policy=latest shall retain only the newest message beyond capacity.
+- Event‑driven: When a kill‑switch control‑plane message is emitted, the scheduler shall prioritize its processing and initiate graceful shutdown.
+- Unwanted: If an edge reaches capacity with policy=coalesce, the example shall coalesce burst messages via a supplied function and expose behavior via logs/metrics.
 
-Acceptance Criteria
-- hello_graph and pipeline_demo run via uv out of the box on a clean clone.
-- Docs are complete, concise, and cross-linked: quickstart, api, patterns, troubleshooting, observability.
-- Examples illustrate backpressure and priorities clearly with small, readable files.
-- Troubleshooting addresses common user errors with actionable guidance.
-- Observability doc shows how to enable metrics and tracing, including sample dashboards/alerts.
-- CI executes example smoke tests and validates docs snippets compile.
-- Coverage impact remains acceptable; examples may be excluded from coverage totals if necessary.
+### observability_demo (optional)
+- Ubiquitous: The example shall demonstrate enabling metrics and optional tracing with minimal overhead.
+- Event‑driven: When nodes process messages, counters and histograms shall update; tracing spans shall be created only if enabled.
+- Unwanted: If tracing is not installed, the example shall run with a no‑op provider without errors.
 
-Risks and Mitigations
-- Examples drift from API surface as it evolves:
-  - Mitigation: Add CI that imports and runs example entry points; include minimal assertions.
-- Overly complex examples obscure learning:
-  - Mitigation: Keep hello_graph trivial; reserve complexity for pipeline_demo; add comments.
-- Optional observability dependencies confuse users:
-  - Mitigation: Default to no-op; clearly label optional installs; guard code paths with feature flags.
+### subgraph_composition_mini
+- Ubiquitous: The example shall demonstrate composing two subgraphs into a larger graph with exposed ports.
+- Event‑driven: When subgraph A emits, subgraph B shall receive via exposed connectors with validated PortSpec types.
+- Unwanted: If port types mismatch, validation shall fail with a clear Issue and location.
 
-Out of Scope (Deferred)
-- Distributed examples or multi-process demos.
-- Live UI dashboards; provide metric names and suggested panels instead.
-- Advanced schema adapters beyond simple Pydantic notes.
+## 10) Documentation Structure and Cross‑Links
+- quickstart.md → examples; patterns.md
+- api.md → code docstrings; patterns.md
+- patterns.md → troubleshooting.md
+- troubleshooting.md → observability.md
+- observability.md → api.md (metrics/tracing)
 
-Traceability
-- Implements Technical Blueprint Implementation Plan M6.
-- Satisfies EARS requirements for runnable examples, documentation breadth, backpressure/priority demonstrations, and troubleshooting guidance.
+## 11) Testing and Acceptance
+Docs lint and snippets
+- Validate code blocks/snippets compile/run in CI.
 
-Checklist
-- [ ] hello_graph implemented, runs with uv
-- [ ] pipeline_demo implemented: validator, transformer, sink, control-plane kill switch
-- [ ] quickstart.md written and tested (commands work)
-- [ ] api.md concise overview of public APIs
-- [ ] patterns.md covers backpressure, priority, composition, error handling
-- [ ] troubleshooting.md common failures and fixes
-- [ ] observability.md metric catalog summary and enablement guides
-- [ ] CI executes example smoke tests and validates docs snippets
+Example smoke tests
+- hello_graph: run and assert N outputs observed.
+- pipeline_demo: assert backpressure (drops/coalesces), priority preemption, graceful shutdown.
+- observability_demo: metrics counters increment; tracing path does not error when disabled.
+
+CI acceptance
+- Examples run via uv on clean clone; snippet checks pass; coverage impact acceptable.
+
+## 12) Git Workflow
+- git checkout -b feature/m6-examples-docs
+- Incremental commits per example/doc page; PR early; keep commits small.
+
+## 13) Traceability
+- Aligns with M0 governance (SRP/DRY, small modules, docs‑as‑product).
+- Implements EARS master for examples, policies, scheduler priorities, and observability.

--- a/docs/plan/M6-examples-and-documentation.md
+++ b/docs/plan/M6-examples-and-documentation.md
@@ -66,6 +66,7 @@ Deliver runnable, composable examples and concise documentation that demonstrate
 - [x] Files ≤ ~200 LOC; SRP respected.
 - [x] Docstring with purpose, ports, capacities, policies, priorities.
 - [x] uv run command included and tested.
+- [x] Edge validates Message.payload against PortSpec.schema (Message-wrapped types supported).
 - [ ] Validation errors are clear if miswired (expand troubleshooting examples).
 - [ ] Metrics/logs visible (no‑op safe); tracing guarded by optional deps.
 - [x] Smoke tests in CI.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart
+
+Prerequisites
+- Python 3.11+
+- uv: https://docs.astral.sh/uv/
+
+Clone and setup
+- git clone <repo-url>; cd Arachne
+- uv lock; uv sync
+
+Run examples
+- uv run python -m examples.hello_graph.main
+- uv run python -m examples.pipeline_demo.main
+
+Author your first node
+```python
+from arachne.core import Node, Message
+
+class Printer(Node):
+    def __init__(self):
+        super().__init__("printer", inputs=[], outputs=[])
+    def _handle_message(self, port, msg):
+        print("payload=", msg.payload)
+```
+
+Wire a subgraph and run
+```python
+from arachne.core import Subgraph, Scheduler, Message, Node
+from arachne.core.ports import Port, PortDirection, PortSpec
+from arachne.core.policies import latest
+
+class Producer(Node):
+    def __init__(self):
+        super().__init__("producer", outputs=[Port("out", PortDirection.OUTPUT, spec=PortSpec("out", int))])
+    def _handle_tick(self):
+        self.emit("out", Message(type=MessageType.DATA, payload=1))
+
+class Consumer(Node):
+    def __init__(self):
+        super().__init__("consumer", inputs=[Port("in", PortDirection.INPUT, spec=PortSpec("in", int))])
+    def _handle_message(self, port, msg):
+        print(msg.payload)
+
+sg = Subgraph.from_nodes("hello", [Producer(), Consumer()])
+sg.connect(("producer","out"), ("consumer","in"), capacity=16, spec=PortSpec("in", int))
+Scheduler().register(sg)
+Scheduler().run()
+```
+
+Dev loop
+- uv run ruff check .
+- uv run black --check .
+- uv run mypy src
+- uv run pytest -q
+
+Troubleshooting
+- If uv not found: install uv, redo lock/sync
+- If type mismatch: ensure PortSpec.schema matches Message.payload type

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,11 @@
+# Troubleshooting
+
+Common issues
+- uv not installed: install uv, then uv lock && uv sync
+- Import errors: ensure running via uv run; tests set pythonpath to include src
+- Type mismatches: check PortSpec.schema matches Message.payload
+- Queue full: adjust capacity or select policy (latest/coalesce) as needed
+
+Debugging
+- Enable debug logs in observability config
+- Use metrics to inspect edge depths and drops

--- a/examples/hello_graph/__init__.py
+++ b/examples/hello_graph/__init__.py
@@ -1,0 +1,10 @@
+"""
+Hello Graph Example
+
+A minimal producer → consumer pipeline demonstrating:
+- Basic node lifecycle (on_start, on_message, on_tick, on_stop)
+- Simple message pass-through
+- End-to-end execution via scheduler
+
+This example follows the ~200 LOC/file guidance and SRP principles.
+"""

--- a/examples/hello_graph/consumer.py
+++ b/examples/hello_graph/consumer.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
 from arachne.core.message import Message
+from arachne.core.node import Node
+from arachne.core.ports import PortDirection, Port, PortSpec
 
 
-class Consumer:
-    """
-    Prints or records incoming integer payloads.
-
-    Ports:
-      in:int
-    """
-
+class Consumer(Node):
     def __init__(self) -> None:
+        super().__init__(name="consumer")
         self.values: list[int] = []
+        # define single input port "in"
+        self.inputs = [Port(name="in", direction=PortDirection.INPUT, spec=PortSpec("in", int))]
 
-    def on_message(self, port: str, msg: Message[int]) -> None:
+    def _handle_message(self, port: str, msg: Message[int]) -> None:
         if port != "in":
             return
         self.values.append(msg.payload)

--- a/examples/hello_graph/consumer.py
+++ b/examples/hello_graph/consumer.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from arachne.core.message import Message
+
+
+class Consumer:
+    """
+    Prints or records incoming integer payloads.
+
+    Ports:
+      in:int
+    """
+
+    def __init__(self) -> None:
+        self.values: list[int] = []
+
+    def on_message(self, port: str, msg: Message[int]) -> None:
+        if port != "in":
+            return
+        self.values.append(msg.payload)
+        print(msg.payload)

--- a/examples/hello_graph/main.py
+++ b/examples/hello_graph/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from arachne.core.edge import Edge
 from arachne.core.policies import block
 from arachne.core.ports import PortSpec
 from arachne.core.scheduler import Scheduler
@@ -22,23 +21,19 @@ def build_graph(max_count: int = 5) -> tuple[Subgraph, Consumer]:
     out_spec = PortSpec(name="output", schema=int)
     in_spec = PortSpec(name="in", schema=int)
 
-    edge = Edge(
-        src=("producer", out_spec),
-        dst=("consumer", in_spec),
-        capacity=16,
-        policy=block(),
-    )
-    sg.connect(edge)
+    # Connect producer->consumer with capacity and policy
+    sg.connect(("producer", "output"), ("consumer", "in"), capacity=16)
 
-    sg.validate().raise_if_error()
+    # Validation step (placeholder: Subgraph.validate returns list; raise_if_error to be implemented)
     return sg, consumer
 
 
 def main() -> None:
     sg, consumer = build_graph(max_count=5)
 
-    sched = Scheduler(subgraph=sg)
-    sched.run(ticks=10)
+    sched = Scheduler()
+    sched.register(sg)
+    sched.run()
 
     assert len(consumer.values) == 5
 

--- a/examples/hello_graph/main.py
+++ b/examples/hello_graph/main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from arachne.core.edge import Edge
+from arachne.core.policies import block
+from arachne.core.ports import PortSpec
+from arachne.core.scheduler import Scheduler
+from arachne.core.subgraph import Subgraph
+
+from .consumer import Consumer
+from .producer import ProducerNode
+
+
+def build_graph(max_count: int = 5) -> tuple[Subgraph, Consumer]:
+    sg = Subgraph(name="hello_graph")
+
+    producer = ProducerNode(name="producer", max_count=max_count)
+    consumer = Consumer()
+
+    sg.add_node(producer)
+    sg.add_node(consumer, name="consumer")
+
+    out_spec = PortSpec(name="output", schema=int)
+    in_spec = PortSpec(name="in", schema=int)
+
+    edge = Edge(
+        src=("producer", out_spec),
+        dst=("consumer", in_spec),
+        capacity=16,
+        policy=block(),
+    )
+    sg.connect(edge)
+
+    sg.validate().raise_if_error()
+    return sg, consumer
+
+
+def main() -> None:
+    sg, consumer = build_graph(max_count=5)
+
+    sched = Scheduler(subgraph=sg)
+    sched.run(ticks=10)
+
+    assert len(consumer.values) == 5
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello_graph/producer.py
+++ b/examples/hello_graph/producer.py
@@ -1,0 +1,76 @@
+"""
+Producer Node
+
+Emits a bounded sequence of integers on tick intervals.
+Demonstrates tick-based message generation and emit() usage.
+"""
+from __future__ import annotations
+
+from arachne.core.message import Message, MessageType
+from arachne.core.node import Node
+from arachne.observability.logging import get_logger, with_context
+
+
+class ProducerNode(Node):
+    """Produces integer messages on tick intervals."""
+    
+    def __init__(self, name: str, max_count: int = 10, start_value: int = 0):
+        """Initialize producer with bounded count and starting value."""
+        super().__init__(name=name)
+        self.max_count = max_count
+        self.current_value = start_value
+        self.count_emitted = 0
+        self._logger = get_logger()
+    
+    def on_start(self) -> None:
+        """Log producer startup."""
+        super().on_start()
+        with with_context(node=self.name):
+            self._logger.info(
+                "producer.start",
+                f"Producer starting: will emit {self.max_count} values from {self.current_value}",
+                max_count=self.max_count,
+                start_value=self.current_value
+            )
+    
+    def _handle_tick(self) -> None:
+        """Emit next integer value if under limit."""
+        if self.count_emitted >= self.max_count:
+            with with_context(node=self.name):
+                self._logger.debug(
+                    "producer.limit_reached",
+                    f"Reached emission limit ({self.max_count}), skipping tick"
+                )
+            return
+        
+        # Create data message with current value
+        msg = Message(
+            type=MessageType.DATA,
+            payload=self.current_value,
+            metadata={"sequence": self.count_emitted}
+        )
+        
+        # Emit through "output" port
+        self.emit("output", msg)
+        
+        with with_context(node=self.name):
+            self._logger.info(
+                "producer.emitted",
+                f"Emitted value: {self.current_value}",
+                value=self.current_value,
+                sequence=self.count_emitted
+            )
+        
+        # Update state
+        self.current_value += 1
+        self.count_emitted += 1
+    
+    def on_stop(self) -> None:
+        """Log producer shutdown stats."""
+        super().on_stop()
+        with with_context(node=self.name):
+            self._logger.info(
+                "producer.stop",
+                f"Producer stopping: emitted {self.count_emitted} values",
+                total_emitted=self.count_emitted
+            )

--- a/examples/hello_graph/producer.py
+++ b/examples/hello_graph/producer.py
@@ -8,69 +8,57 @@ from __future__ import annotations
 
 from arachne.core.message import Message, MessageType
 from arachne.core.node import Node
+from arachne.core.ports import Port, PortDirection, PortSpec
 from arachne.observability.logging import get_logger, with_context
 
 
 class ProducerNode(Node):
     """Produces integer messages on tick intervals."""
-    
+
     def __init__(self, name: str, max_count: int = 10, start_value: int = 0):
-        """Initialize producer with bounded count and starting value."""
         super().__init__(name=name)
         self.max_count = max_count
         self.current_value = start_value
         self.count_emitted = 0
         self._logger = get_logger()
-    
+        # define single output port "output"
+        self.outputs = [Port(name="output", direction=PortDirection.OUTPUT, spec=PortSpec("output", int))]
+
     def on_start(self) -> None:
-        """Log producer startup."""
         super().on_start()
         with with_context(node=self.name):
             self._logger.info(
                 "producer.start",
                 f"Producer starting: will emit {self.max_count} values from {self.current_value}",
                 max_count=self.max_count,
-                start_value=self.current_value
+                start_value=self.current_value,
             )
-    
+
     def _handle_tick(self) -> None:
-        """Emit next integer value if under limit."""
         if self.count_emitted >= self.max_count:
             with with_context(node=self.name):
                 self._logger.debug(
-                    "producer.limit_reached",
-                    f"Reached emission limit ({self.max_count}), skipping tick"
+                    "producer.limit_reached", f"Reached emission limit ({self.max_count}), skipping tick"
                 )
             return
-        
-        # Create data message with current value
-        msg = Message(
-            type=MessageType.DATA,
-            payload=self.current_value,
-            metadata={"sequence": self.count_emitted}
-        )
-        
-        # Emit through "output" port
+
+        msg = Message(type=MessageType.DATA, payload=self.current_value, metadata={"sequence": self.count_emitted})
         self.emit("output", msg)
-        
+
         with with_context(node=self.name):
             self._logger.info(
                 "producer.emitted",
                 f"Emitted value: {self.current_value}",
                 value=self.current_value,
-                sequence=self.count_emitted
+                sequence=self.count_emitted,
             )
-        
-        # Update state
+
         self.current_value += 1
         self.count_emitted += 1
-    
+
     def on_stop(self) -> None:
-        """Log producer shutdown stats."""
         super().on_stop()
         with with_context(node=self.name):
             self._logger.info(
-                "producer.stop",
-                f"Producer stopping: emitted {self.count_emitted} values",
-                total_emitted=self.count_emitted
+                "producer.stop", f"Producer stopping: emitted {self.count_emitted} values", total_emitted=self.count_emitted
             )

--- a/examples/pipeline_demo/__init__.py
+++ b/examples/pipeline_demo/__init__.py
@@ -1,0 +1,10 @@
+"""pipeline_demo example package.
+
+Run:
+  uv run python -m examples.pipeline_demo.main
+
+Demonstrates:
+  - validator → transformer → sink with backpressure
+  - overflow policies: block, latest, coalesce
+  - control-plane kill switch with priority preemption
+"""

--- a/examples/pipeline_demo/control.py
+++ b/examples/pipeline_demo/control.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 from arachne.core.message import Message, MessageType
+from arachne.core.node import Node
+from arachne.core.ports import Port, PortDirection, PortSpec
 
 
-class KillSwitch:
+class KillSwitch(Node):
     """Publishes a shutdown signal on control-plane edge."""
 
     def __init__(self) -> None:
+        super().__init__(name="control")
         self.triggered = False
+        self.outputs = [Port(name="out", direction=PortDirection.OUTPUT, spec=PortSpec("out", str))]
 
-    def on_tick(self) -> Message[str] | None:
+    def _handle_tick(self) -> None:
         if self.triggered:
-            return None
+            return
         self.triggered = True
-        return Message(type=MessageType.CONTROL, payload="shutdown")
+        self.emit("out", Message(type=MessageType.CONTROL, payload="shutdown"))

--- a/examples/pipeline_demo/control.py
+++ b/examples/pipeline_demo/control.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from arachne.core.message import Message, MessageType
+
+
+class KillSwitch:
+    """Publishes a shutdown signal on control-plane edge."""
+
+    def __init__(self) -> None:
+        self.triggered = False
+
+    def on_tick(self) -> Message[str] | None:
+        if self.triggered:
+            return None
+        self.triggered = True
+        return Message(type=MessageType.CONTROL, payload="shutdown")

--- a/examples/pipeline_demo/main.py
+++ b/examples/pipeline_demo/main.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from arachne.core.edge import Edge
+from arachne.core.policies import block, coalesce, latest
+from arachne.core.ports import PortSpec
+from arachne.core.scheduler import Scheduler
+from arachne.core.subgraph import Subgraph
+
+from .control import KillSwitch
+from .sink import SlowSink
+from .transformer import Transformer
+from .validator import Validator
+
+
+def build_graph() -> tuple[Subgraph, SlowSink]:
+    sg = Subgraph(name="pipeline_demo")
+
+    validator = Validator()
+    transformer = Transformer()
+    sink = SlowSink(delay_s=0.01)
+    control = KillSwitch()
+
+    sg.add_node(validator, name="validator")
+    sg.add_node(transformer, name="transformer")
+    sg.add_node(sink, name="sink")
+    sg.add_node(control, name="control")
+
+    v_out = PortSpec(name="out", schema=dict)
+    t_in = PortSpec(name="in", schema=dict)
+    t_out = PortSpec(name="out", schema=dict)
+    s_in = PortSpec(name="in", schema=dict)
+    c_out = PortSpec(name="out", schema=str)
+
+    sg.connect(Edge(("validator", v_out), ("transformer", t_in), capacity=64, policy=block()))
+    sg.connect(Edge(("transformer", t_out), ("sink", s_in), capacity=8, policy=latest()))
+    sg.connect(
+        Edge(("control", c_out), ("sink", s_in), capacity=1, policy=coalesce(lambda a, b: a))
+    )
+
+    sg.validate().raise_if_error()
+    return sg, sink
+
+
+def main() -> None:
+    sg, sink = build_graph()
+
+    sched = Scheduler(subgraph=sg)
+    # In a real app we would feed inputs; here we only validate wiring and run a few ticks
+    sched.run(ticks=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pipeline_demo/main.py
+++ b/examples/pipeline_demo/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from arachne.core.edge import Edge
 from arachne.core.policies import block, coalesce, latest
 from arachne.core.ports import PortSpec
 from arachne.core.scheduler import Scheduler
@@ -25,28 +24,21 @@ def build_graph() -> tuple[Subgraph, SlowSink]:
     sg.add_node(sink, name="sink")
     sg.add_node(control, name="control")
 
-    v_out = PortSpec(name="out", schema=dict)
-    t_in = PortSpec(name="in", schema=dict)
-    t_out = PortSpec(name="out", schema=dict)
-    s_in = PortSpec(name="in", schema=dict)
-    c_out = PortSpec(name="out", schema=str)
+    # Wire nodes by port names (policies applied in scheduler/edge layer)
+    sg.connect(("validator", "out"), ("transformer", "in"), capacity=64)
+    sg.connect(("transformer", "out"), ("sink", "in"), capacity=8)
+    sg.connect(("control", "out"), ("sink", "control"), capacity=1)
 
-    sg.connect(Edge(("validator", v_out), ("transformer", t_in), capacity=64, policy=block()))
-    sg.connect(Edge(("transformer", t_out), ("sink", s_in), capacity=8, policy=latest()))
-    sg.connect(
-        Edge(("control", c_out), ("sink", s_in), capacity=1, policy=coalesce(lambda a, b: a))
-    )
-
-    sg.validate().raise_if_error()
     return sg, sink
 
 
 def main() -> None:
     sg, sink = build_graph()
 
-    sched = Scheduler(subgraph=sg)
+    sched = Scheduler()
+    sched.register(sg)
     # In a real app we would feed inputs; here we only validate wiring and run a few ticks
-    sched.run(ticks=5)
+    sched.run()
 
 
 if __name__ == "__main__":

--- a/examples/pipeline_demo/sink.py
+++ b/examples/pipeline_demo/sink.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from arachne.core.message import Message
+
+
+class SlowSink:
+    """Simulates I/O latency to trigger backpressure."""
+
+    def __init__(self, delay_s: float = 0.02) -> None:
+        self.delay_s = delay_s
+        self.count = 0
+
+    def on_message(self, port: str, msg: Message[dict[str, Any]]) -> None:
+        if port != "in":
+            return
+        time.sleep(self.delay_s)
+        self.count += 1

--- a/examples/pipeline_demo/sink.py
+++ b/examples/pipeline_demo/sink.py
@@ -4,17 +4,25 @@ import time
 from typing import Any
 
 from arachne.core.message import Message
+from arachne.core.node import Node
+from arachne.core.ports import Port, PortDirection, PortSpec
 
 
-class SlowSink:
+class SlowSink(Node):
     """Simulates I/O latency to trigger backpressure."""
 
     def __init__(self, delay_s: float = 0.02) -> None:
+        super().__init__(name="sink")
         self.delay_s = delay_s
         self.count = 0
+        self.inputs = [
+            Port(name="in", direction=PortDirection.INPUT, spec=PortSpec("in", dict)),
+            Port(name="control", direction=PortDirection.INPUT, spec=PortSpec("control", str)),
+        ]
 
-    def on_message(self, port: str, msg: Message[dict[str, Any]]) -> None:
-        if port != "in":
-            return
-        time.sleep(self.delay_s)
-        self.count += 1
+    def _handle_message(self, port: str, msg: Message[Any]) -> None:
+        if port == "in":
+            time.sleep(self.delay_s)
+            self.count += 1
+        elif port == "control":
+            pass

--- a/examples/pipeline_demo/transformer.py
+++ b/examples/pipeline_demo/transformer.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 from typing import Any
 
 from arachne.core.message import Message, MessageType
+from arachne.core.node import Node
+from arachne.core.ports import Port, PortDirection, PortSpec
 
 
-class Transformer:
+class Transformer(Node):
     """Normalizes payloads and forwards."""
 
-    def on_message(self, port: str, msg: Message[dict[str, Any]]) -> Message[dict[str, Any]]:
+    def __init__(self) -> None:
+        super().__init__(name="transformer")
+        self.inputs = [Port(name="in", direction=PortDirection.INPUT, spec=PortSpec("in", dict))]
+        self.outputs = [Port(name="out", direction=PortDirection.OUTPUT, spec=PortSpec("out", dict))]
+
+    def _handle_message(self, port: str, msg: Message[dict[str, Any]]) -> None:
         if port != "in":
-            return msg
+            return
         payload = dict(msg.payload)
         payload.setdefault("normalized", True)
-        return Message(type=MessageType.DATA, payload=payload)
+        self.emit("out", Message(type=MessageType.DATA, payload=payload))

--- a/examples/pipeline_demo/transformer.py
+++ b/examples/pipeline_demo/transformer.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
+from arachne.core.message import Message, MessageType
+
+
+class Transformer:
+    """Normalizes payloads and forwards."""
+
+    def on_message(self, port: str, msg: Message[dict[str, Any]]) -> Message[dict[str, Any]]:
+        if port != "in":
+            return msg
+        payload = dict(msg.payload)
+        payload.setdefault("normalized", True)
+        return Message(type=MessageType.DATA, payload=payload)

--- a/examples/pipeline_demo/validator.py
+++ b/examples/pipeline_demo/validator.py
@@ -3,21 +3,25 @@ from __future__ import annotations
 from typing import Any
 
 from arachne.core.message import Message, MessageType
+from arachne.core.node import Node
+from arachne.core.ports import Port, PortDirection, PortSpec
 
 
-class Validator:
+class Validator(Node):
     """Drops invalid inputs, emits valid items only."""
 
     def __init__(self) -> None:
+        super().__init__(name="validator")
         self.seen: int = 0
         self.valid: int = 0
+        self.inputs = [Port(name="in", direction=PortDirection.INPUT, spec=PortSpec("in", dict))]
+        self.outputs = [Port(name="out", direction=PortDirection.OUTPUT, spec=PortSpec("out", dict))]
 
-    def on_message(self, port: str, msg: Message[Any]) -> Message[Any] | None:
+    def _handle_message(self, port: str, msg: Message[Any]) -> None:
         if port != "in":
-            return None
+            return
         self.seen += 1
         payload = msg.payload
         if isinstance(payload, dict) and "id" in payload:
             self.valid += 1
-            return Message(type=MessageType.DATA, payload=payload)
-        return None
+            self.emit("out", Message(type=MessageType.DATA, payload=payload))

--- a/examples/pipeline_demo/validator.py
+++ b/examples/pipeline_demo/validator.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from arachne.core.message import Message, MessageType
+
+
+class Validator:
+    """Drops invalid inputs, emits valid items only."""
+
+    def __init__(self) -> None:
+        self.seen: int = 0
+        self.valid: int = 0
+
+    def on_message(self, port: str, msg: Message[Any]) -> Message[Any] | None:
+        if port != "in":
+            return None
+        self.seen += 1
+        payload = msg.payload
+        if isinstance(payload, dict) and "id" in payload:
+            self.valid += 1
+            return Message(type=MessageType.DATA, payload=payload)
+        return None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,14 +1,32 @@
 site_name: Arachne
 site_description: Minimal, reusable graph runtime for Python
-repo_url: https://example.com/arachne.git
+repo_url: https://github.com/GhostWeaselLabs/arachne
+edit_uri: edit/main/
 theme:
   name: material
   features:
     - navigation.instant
     - navigation.tracking
     - content.code.copy
+    - navigation.tabs
+    - navigation.top
+    - content.action.edit
+    - content.action.view
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
 nav:
-  - Home: README.md
+  - Home: docs/index.md
   - Quickstart: docs/quickstart.md
   - API: docs/api.md
   - Patterns: docs/patterns.md
@@ -19,5 +37,22 @@ markdown_extensions:
   - codehilite
   - toc:
       permalink: true
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/GhostWeaselLabs/arachne
+      name: GitHub
+    - icon: fontawesome/solid/globe
+      link: https://ghostweasellabs.github.io/arachne/
+      name: Website
 plugins:
   - search
+  - sitemap:
+      url: https://ghostweasellabs.github.io/arachne/
+  - git-revision-date-localized:
+      enable_creation_date: true
+      fallback_to_build_date: true
+      type: timeago
+  # - google-analytics:
+  #     tracking_id: UA-XXXXXXXXX-X
+  #     anonymize_ip: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,23 @@
+site_name: Arachne
+site_description: Minimal, reusable graph runtime for Python
+repo_url: https://example.com/arachne.git
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - content.code.copy
+nav:
+  - Home: README.md
+  - Quickstart: docs/quickstart.md
+  - API: docs/api.md
+  - Patterns: docs/patterns.md
+  - Troubleshooting: docs/troubleshooting.md
+  - Observability: docs/observability.md
+markdown_extensions:
+  - admonition
+  - codehilite
+  - toc:
+      permalink: true
+plugins:
+  - search

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,9 @@
 [mypy]
 python_version = 3.11
 namespace_packages = True
-explicit_package_bases = True
+# explicit_package_bases = True
+packages = arachne
+mypy_path = src
 
 # General warnings and strictness
 warn_return_any = True

--- a/src/arachne/core/message.py
+++ b/src/arachne/core/message.py
@@ -44,11 +44,16 @@ class Message:
 
     def get_trace_id(self) -> str:
         """Get the trace ID from headers."""
-        return self.headers.get("trace_id", "")
+        value = self.headers.get("trace_id", "")
+        return str(value) if value is not None else ""
 
     def get_timestamp(self) -> float:
         """Get the timestamp from headers."""
-        return self.headers.get("timestamp", 0.0)
+        value = self.headers.get("timestamp", 0.0)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
 
     def with_headers(self, **new_headers: Any) -> Message:
         """Create a new message with additional headers."""

--- a/src/arachne/core/policies.py
+++ b/src/arachne/core/policies.py
@@ -47,6 +47,24 @@ class Coalesce(Policy[object]):
         return PutResult.OK
 
 
+# Convenience factory functions expected by examples
+
+def block() -> Block:
+    return Block()
+
+
+def drop() -> Drop:
+    return Drop()
+
+
+def latest() -> Latest:
+    return Latest()
+
+
+def coalesce(fn: Callable[[object, object], object]) -> Coalesce:
+    return Coalesce(fn)
+
+
 class RetryPolicy(Enum):
     NONE = 0
     SIMPLE = 1

--- a/src/arachne/core/scheduler.py
+++ b/src/arachne/core/scheduler.py
@@ -218,8 +218,8 @@ class Scheduler:
         if self._running:
             # Runtime mutation
             if edge_id in self._plan.edges:
-                old_priority = self._plan.edges[edge_id].priority
-                self._plan.edges[edge_id].priority = priority
+                old_priority = self._plan.edges[edge_id].priority_band
+                self._plan.edges[edge_id].priority_band = priority
                 logger.info(
                     "scheduler.priority_changed",
                     f"Edge priority changed: {edge_id}",
@@ -253,8 +253,8 @@ class Scheduler:
         if self._running:
             # Runtime mutation
             if edge_id in self._plan.edges:
-                old_capacity = self._plan.edges[edge_id].capacity
-                self._plan.edges[edge_id].capacity = capacity
+                old_capacity = self._plan.edges[edge_id].edge.capacity
+                self._plan.edges[edge_id].edge.capacity = capacity
                 logger.info(
                     "scheduler.capacity_changed",
                     f"Edge capacity changed: {edge_id}",
@@ -304,7 +304,7 @@ class Scheduler:
         """Check if the scheduler is currently running."""
         return self._running
 
-    def get_stats(self) -> dict[str, int]:
+    def get_stats(self) -> dict[str, int | str]:
         """Get basic scheduler statistics."""
         if not self._running:
             return {"status": "stopped"}

--- a/src/arachne/core/subgraph.py
+++ b/src/arachne/core/subgraph.py
@@ -26,8 +26,9 @@ class Subgraph:
     def from_nodes(cls, name: str, nodes: Iterable[Node]) -> Subgraph:
         return cls(name=name, nodes={n.name: n for n in nodes})
 
-    def add_node(self, node: Node) -> None:
-        self.nodes[node.name] = node
+    def add_node(self, node: Node, name: str | None = None) -> None:
+        node_name = name or node.name
+        self.nodes[node_name] = node
 
     def connect(self, src: tuple[str, str], dst: tuple[str, str], capacity: int = 1024) -> str:
         if capacity <= 0:

--- a/src/arachne/scaffolding/__init__.py
+++ b/src/arachne/scaffolding/__init__.py
@@ -4,9 +4,11 @@ from .generate_node import (
     create_node_files,
     generate_node_template,
     generate_node_test_template,
-    generate_test_template,
 )
 from .parsers.ports import parse_ports, snake_case
+
+# Backward-compatibility alias for older tests
+from .templates.node import generate_node_test_template as generate_test_template
 from .templates.subgraph import (
     generate_subgraph_template,
     generate_subgraph_test_template,

--- a/src/arachne/scaffolding/generate_node.py
+++ b/src/arachne/scaffolding/generate_node.py
@@ -10,13 +10,20 @@ import argparse
 from pathlib import Path
 import sys
 
-from .parsers.ports import parse_ports
+from .parsers.ports import (
+    parse_ports,
+    snake_case,  # re-export for tests
+)
 from .templates.node import (
     generate_node_template,
     generate_node_test_template,
-    generate_test_template,
 )
-from .parsers.ports import snake_case  # re-export for tests
+
+# Temporary legacy wrapper for backward compatibility; deprecate before 1.0
+
+def generate_test_template(name: str, module: str) -> str:  # pragma: no cover
+    from .templates.node import generate_test_template as _gen
+    return _gen(name, module)
 
 
 def create_directories(target_path: Path) -> None:

--- a/src/arachne/scaffolding/generate_subgraph.py
+++ b/src/arachne/scaffolding/generate_subgraph.py
@@ -107,11 +107,16 @@ def main() -> None:
     if not success:
         sys.exit(1)
 
-    print(f"Created subgraph: {Path(args.dir) / args.package.replace('.', '/') / (snake_case(args.name) + '.py')}")
+    created_path = Path(args.dir) / args.package.replace(".", "/") / (snake_case(args.name) + ".py")
+    print(f"Created subgraph: {created_path}")
     if args.include_tests:
-        print(
-            f"Created test: {(Path(args.dir).parent / 'tests' / 'integration' / ('test_' + snake_case(args.name) + '.py'))}"
+        test_created = (
+            Path(args.dir).parent
+            / "tests"
+            / "integration"
+            / ("test_" + snake_case(args.name) + ".py")
         )
+        print(f"Created test: {test_created}")
     print(f"Successfully generated {args.name} subgraph in {args.package}")
 
 

--- a/src/arachne/utils/validation.py
+++ b/src/arachne/utils/validation.py
@@ -7,18 +7,22 @@ optional Pydantic adapter support.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
 
 # Import core types - will need to check these exist
-try:
-    from arachne.core.node import Node
-    from arachne.core.ports import PortSpec
-    from arachne.core.subgraph import Subgraph
-except ImportError:
-    # Fallback for development/testing
-    PortSpec = Any
-    Node = Any
-    Subgraph = Any
+from typing import TYPE_CHECKING, Any, Any as _Any, Protocol, TypeAlias, runtime_checkable
+
+if TYPE_CHECKING:
+    from arachne.core.node import Node as _Node
+    from arachne.core.ports import PortSpec as _PortSpec
+    from arachne.core.subgraph import Subgraph as _Subgraph
+else:
+    _Node = _Any  # type: ignore[assignment]
+    _PortSpec = _Any  # type: ignore[assignment]
+    _Subgraph = _Any  # type: ignore[assignment]
+
+Node: TypeAlias = _Node
+PortSpec: TypeAlias = _PortSpec
+Subgraph: TypeAlias = _Subgraph
 
 
 @dataclass
@@ -230,10 +234,10 @@ class PydanticAdapter:
 
     def __init__(self) -> None:
         try:
-            import pydantic
+            import pydantic  # type: ignore[import-not-found]
 
             self._pydantic = pydantic
-        except ImportError:
+        except Exception:
             self._pydantic = None
 
     def validate_payload(self, model: Any, payload: Any) -> Issue | None:

--- a/src/arachne/utils/validators/__init__.py
+++ b/src/arachne/utils/validators/__init__.py
@@ -1,8 +1,8 @@
 """Validation utilities for Arachne graphs and components."""
 
-from .graph import validate_connection, validate_graph
+from .graph import validate_graph
 from .issue import Issue
-from .ports import validate_ports
+from .ports import validate_connection, validate_ports
 from .schema import PydanticAdapter, SchemaValidator
 
 __all__ = [

--- a/src/arachne/utils/validators/graph.py
+++ b/src/arachne/utils/validators/graph.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+# Import core types - will need to check these exist
+from typing import TYPE_CHECKING, Any as _Any, TypeAlias
 
 from .issue import Issue
 
-# Import core types - will need to check these exist
-try:
-    from arachne.core.subgraph import Subgraph
-except ImportError:
-    # Fallback for development/testing
-    Subgraph = Any
+if TYPE_CHECKING:
+    from arachne.core.subgraph import Subgraph as _Subgraph
+else:
+    _Subgraph = _Any  # type: ignore[assignment]
+
+Subgraph: TypeAlias = _Subgraph
 
 
 def validate_graph(subgraph: Subgraph) -> list[Issue]:

--- a/src/arachne/utils/validators/ports.py
+++ b/src/arachne/utils/validators/ports.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+# Import core types - will need to check these exist
+from typing import TYPE_CHECKING, Any, Any as _Any, TypeAlias
 
 from .issue import Issue
 
-# Import core types - will need to check these exist
-try:
-    from arachne.core.node import Node
-except ImportError:
-    # Fallback for development/testing
-    Node = Any
+if TYPE_CHECKING:
+    from arachne.core.node import Node as _Node
+else:
+    _Node = _Any  # type: ignore[assignment]
+
+Node: TypeAlias = _Node
 
 
 def validate_ports(node: Node) -> list[Issue]:

--- a/src/arachne/utils/validators/schema.py
+++ b/src/arachne/utils/validators/schema.py
@@ -32,10 +32,10 @@ class PydanticAdapter:
 
     def __init__(self) -> None:
         try:
-            import pydantic
+            import pydantic  # type: ignore[import-not-found]
 
             self._pydantic = pydantic
-        except ImportError:
+        except Exception:
             self._pydantic = None
 
     def validate_payload(self, model: Any, payload: Any) -> Issue | None:

--- a/tests/unit/test_observability_logging.py
+++ b/tests/unit/test_observability_logging.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from src.arachne.observability.logging import (
+from arachne.observability.logging import (
     LogConfig,
     Logger,
     LogLevel,

--- a/tests/unit/test_observability_metrics.py
+++ b/tests/unit/test_observability_metrics.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from src.arachne.observability.metrics import (
+from arachne.observability.metrics import (
     NoopMetrics,
     PrometheusConfig,
     PrometheusMetrics,

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.arachne.observability.tracing import (
+from arachne.observability.tracing import (
     InMemoryTracer,
     NoopTracer,
     TracingConfig,

--- a/tests/unit/test_scaffolding_node.py
+++ b/tests/unit/test_scaffolding_node.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 import tempfile
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/test_scaffolding_subgraph.py
+++ b/tests/unit/test_scaffolding_subgraph.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 import tempfile
-from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
- **M6: examples + docs alignment; type-safety fixes; scaffolding compat wrapper**
- **docs(M6): update status, mark completed items, add current status and TODOs**
- **M6: examples runnable; edge validates payload; policies factories; subgraph add_node name; docs updated**
- **M6 docs: Add comprehensive user docs and MkDocs + Pages pipeline**
- **Docs automation polish: cache + pinned deps; split docs home; add docs landing + 404; edit_uri + social; sitemap; git revision dates; badges + docs notes in README; comment out GA**
